### PR TITLE
fix: add recursive option to set collection visibility

### DIFF
--- a/basicnodes/__init__.py
+++ b/basicnodes/__init__.py
@@ -9143,6 +9143,7 @@ class NLActionSetCollectionVisibility(bpy.types.Node, NLActionNode):
         socket.use_toggle = True
         socket.true_label = "Visible"
         socket.false_label = "Not Visibile"
+        self.inputs.new(NLBooleanSocket.bl_idname, "Include Children")
         self.outputs.new(NLConditionSocket.bl_idname, 'Done')
 
     def get_output_socket_varnames(self):
@@ -9152,7 +9153,7 @@ class NLActionSetCollectionVisibility(bpy.types.Node, NLActionNode):
         return "ULSetCollectionVisibility"
 
     def get_input_sockets_field_names(self):
-        return ["condition", "collection", "visible"]
+        return ["condition", "collection", "visible", "recursive"]
 
 
 _nodes.append(NLActionSetCollectionVisibility)


### PR DESCRIPTION
fix: add recursive option to set collection visibility

![image](https://user-images.githubusercontent.com/35925088/151893447-e41ddbca-e65a-4ce0-a065-bb77d7035f31.png)

Blend test file:
[test-set-collection-visibility.zip](https://github.com/UPBGE/UPBGE-logicnodes/files/7974999/test-set-collection-visibility.zip)
